### PR TITLE
Fix event loop stops if the window is not visible

### DIFF
--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -444,10 +444,10 @@ impl IOCompositor {
         }
 
         self.shutdown_state = ShutdownState::ShuttingDown;
-        self.finish_shutting_down();
     }
 
-    fn finish_shutting_down(&mut self) {
+    /// Finish shutting down when we receive `EmbedderMsg::ShutdownComplete`
+    pub fn finish_shutting_down(&mut self) {
         debug!("Compositor received message that constellation shutdown is complete");
 
         // Drain compositor port, sometimes messages contain channels that are blocking

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ impl ApplicationHandler<EventLoopProxyMessage> for App {
                     v.request_redraw(event_loop);
                 }
                 EventLoopProxyMessage::IpcMessage(message) => {
-                    v.handle_incoming_webview_message(*message);
+                    v.handle_incoming_webview_message(event_loop, *message);
                 }
             }
         }


### PR DESCRIPTION
This fixes the bug that the entire app freezes if the window's visibility is set to false