### PR TITLE
Support setting and getting title dynamically

### DIFF
--- a/src/verso.rs
+++ b/src/verso.rs
@@ -675,7 +675,7 @@ impl Verso {
             }
             ToVersoMessage::SetTitle(title) => {
                 if let Some(window) = self.first_window() {
-                    let _ = window.window.set_title(&title);
+                    window.window.set_title(&title);
                 }
             }
             ToVersoMessage::SetSize(size) => {

--- a/src/verso.rs
+++ b/src/verso.rs
@@ -673,6 +673,11 @@ impl Verso {
                     }
                 }
             }
+            ToVersoMessage::SetTitle(title) => {
+                if let Some(window) = self.first_window() {
+                    let _ = window.window.set_title(&title);
+                }
+            }
             ToVersoMessage::SetSize(size) => {
                 if let Some(window) = self.first_window() {
                     let _ = window.window.request_inner_size(size);
@@ -722,6 +727,15 @@ impl Verso {
             ToVersoMessage::Focus => {
                 if let Some(window) = self.first_window() {
                     window.window.focus_window();
+                }
+            }
+            ToVersoMessage::GetTitle(id) => {
+                if let Some(window) = self.first_window() {
+                    if let Err(error) = self.to_controller_sender.as_ref().unwrap().send(
+                        ToControllerMessage::GetTitleResponse(id, window.window.title()),
+                    ) {
+                        log::error!("Verso failed to send GetTitleReponse to controller: {error}")
+                    }
                 }
             }
             ToVersoMessage::GetSize(id, size_type) => {
@@ -840,7 +854,11 @@ impl Verso {
                     }
                 }
             }
-            _ => {}
+            ToVersoMessage::SetConfig(..) => {
+                log::error!(
+                    "`ToVersoMessage::SetConfig` should not be received after the initial setup"
+                )
+            }
         }
     }
 

--- a/versoview_messages/src/lib.rs
+++ b/versoview_messages/src/lib.rs
@@ -13,7 +13,6 @@ type SerializedPipelineId = Vec<u8>;
 
 /// Message sent from the controller to versoview
 #[derive(Debug, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum ToVersoMessage {
     /// Initial configs for versoview
     /// this will be the first message sent to Verso once we received the sender from [`ToControllerMessage::SetToVersoSender`]
@@ -38,6 +37,8 @@ pub enum ToVersoMessage {
     ListenToWebResourceRequests,
     /// Response to a [`ToControllerMessage::OnWebResourceRequested`] message from versoview
     WebResourceRequestResponse(WebResourceRequestResponse),
+    /// Sets the window title
+    SetTitle(String),
     /// Sets the webview window's size
     SetSize(Size),
     /// Sets the webview window's position
@@ -56,6 +57,8 @@ pub enum ToVersoMessage {
     StartDragging,
     /// Bring the window to the front, and capture input focus
     Focus,
+    /// Get the title of the window, need a response with [`ToControllerMessage::GetTitleResponse`]
+    GetTitle(uuid::Uuid),
     /// Get the window's size, need a response with [`ToControllerMessage::GetSizeResponse`]
     GetSize(uuid::Uuid, SizeType),
     /// Get the window's position, need a response with [`ToControllerMessage::GetPositionResponse`]
@@ -88,7 +91,6 @@ pub enum SizeType {
 
 /// Message sent from versoview to the controller
 #[derive(Debug, Serialize, Deserialize)]
-#[non_exhaustive]
 pub enum ToControllerMessage {
     /// IPC sender for the controller to send commands to versoview,
     /// this will be the first message sent to the controller once connected
@@ -97,6 +99,8 @@ pub enum ToControllerMessage {
     OnNavigationStarting(SerializedPipelineId, url::Url),
     /// Sent on a new web resource request, need a response with [`ToVersoMessage::WebResourceRequestResponse`]
     OnWebResourceRequested(WebResourceRequest),
+    /// Response to a [`ToVersoMessage::GetTitle`]
+    GetTitleResponse(uuid::Uuid, String),
     /// Response to a [`ToVersoMessage::GetSize`]
     GetSizeResponse(uuid::Uuid, PhysicalSize<u32>),
     /// Response to a [`ToVersoMessage::GetPosition`]


### PR DESCRIPTION
This also removes the `non_exhaustive` mark on `ToVersoMessage` and `ToControllerMessage` since they're only used internally, and we don't care about breaking changes, this helps with catching fields that are not handled by mistakes