### PR TITLE
Add basic support for themes

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -648,6 +648,12 @@ impl Window {
                 }
                 forward_input_event(compositor, webview_id, sender, InputEvent::Keyboard(event));
             }
+            WindowEvent::ThemeChanged(theme) => {
+                let _ = sender.send(EmbedderToConstellationMessage::ThemeChange(match theme {
+                    winit::window::Theme::Light => embedder_traits::Theme::Light,
+                    winit::window::Theme::Dark => embedder_traits::Theme::Dark,
+                }));
+            }
             e => log::trace!("Verso Window isn't supporting this window event yet: {e:?}"),
         }
     }


### PR DESCRIPTION
This only adds support for notifying Servo on Winit theme events, there're still a lot of bugs that made this not so useful:

- We don't have a way to set initial theme yet https://github.com/servo/servo/issues/34913
- Servo doesn't trigger a re-layout on getting the change theme event for the page immediately, so the page will only be changing theme on next thing that triggers a re-layout
- The theme is lost on page reload