### PR TITLE
Bump Servo to 2d3a7c8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
 dependencies = [
  "async-channel",
  "async-io",
@@ -451,7 +451,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "tracing",
 ]
 
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
 dependencies = [
  "async-io",
  "async-lock",
@@ -478,7 +478,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -611,7 +611,7 @@ dependencies = [
 [[package]]
 name = "background_hang_monitor"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "background_hang_monitor_api",
  "backtrace",
@@ -629,7 +629,7 @@ dependencies = [
 [[package]]
 name = "background_hang_monitor_api"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "ipc-channel",
@@ -654,7 +654,7 @@ dependencies = [
 [[package]]
 name = "base"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -832,7 +832,7 @@ dependencies = [
 [[package]]
 name = "bluetooth"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "bitflags 2.9.1",
@@ -849,7 +849,7 @@ dependencies = [
 [[package]]
 name = "bluetooth_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "embedder_traits",
@@ -1019,7 +1019,7 @@ dependencies = [
 [[package]]
 name = "canvas"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "app_units",
  "canvas_traits",
@@ -1046,7 +1046,7 @@ dependencies = [
 [[package]]
 name = "canvas_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -1282,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "compositing_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "bincode",
@@ -1321,7 +1321,7 @@ dependencies = [
 [[package]]
 name = "constellation"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "background_hang_monitor",
  "background_hang_monitor_api",
@@ -1363,7 +1363,7 @@ dependencies = [
 [[package]]
 name = "constellation_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "canvas_traits",
@@ -1380,6 +1380,7 @@ dependencies = [
  "serde",
  "servo_malloc_size_of",
  "servo_url",
+ "snapshot",
  "strum",
  "strum_macros",
  "uuid",
@@ -1650,7 +1651,7 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 [[package]]
 name = "deny_public_fields"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "syn 2.0.101",
  "synstructure",
@@ -1680,7 +1681,7 @@ dependencies = [
 [[package]]
 name = "devtools"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "chrono",
@@ -1703,7 +1704,7 @@ dependencies = [
 [[package]]
 name = "devtools_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "bitflags 2.9.1",
@@ -1766,23 +1767,23 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "5.0.1"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys",
 ]
 
 [[package]]
 name = "dirs-sys"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1845,7 +1846,7 @@ dependencies = [
 [[package]]
 name = "dom_struct"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "quote",
  "syn 2.0.101",
@@ -1854,7 +1855,7 @@ dependencies = [
 [[package]]
 name = "domobject_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1920,7 +1921,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "embedder_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "cookie 0.18.1",
@@ -2168,6 +2169,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "float-ord"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,9 +2194,9 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "font-kit"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b64b34f4efd515f905952d91bc185039863705592c0c53ae6d979805dd154520"
+checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
 dependencies = [
  "bitflags 2.9.1",
  "byteorder",
@@ -2211,9 +2218,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "fontconfig-parser"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser",
+]
+
+[[package]]
 name = "fonts"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -2263,7 +2293,7 @@ dependencies = [
 [[package]]
 name = "fonts_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "malloc_size_of_derive",
  "range",
@@ -3272,12 +3302,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
+checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
 dependencies = [
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
@@ -3293,7 +3324,7 @@ dependencies = [
 [[package]]
 name = "hyper_serde"
 version = "0.13.2"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "cookie 0.18.1",
  "headers 0.4.0",
@@ -3910,6 +3941,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edcd27d72f2f071c64249075f42e205ff93c9a4c5f6c6da53e79ed9f9832c285"
+
+[[package]]
 name = "imgref"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4100,7 +4137,7 @@ dependencies = [
 [[package]]
 name = "jstraceable_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "proc-macro2",
  "syn 2.0.101",
@@ -4136,9 +4173,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "kurbo"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1077d333efea6170d9ccb96d3c3026f300ca0773da4938cc4c811daa6df68b0c"
+dependencies = [
+ "arrayvec",
+ "smallvec",
+]
+
+[[package]]
 name = "layout"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -4237,9 +4284,9 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a793df0d7afeac54f95b471d3af7f0d4fb975699f972341a4b76988d49cdf0c"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
  "windows-targets 0.53.0",
@@ -4447,7 +4494,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "compositing_traits",
  "euclid",
@@ -4516,7 +4563,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "ipc-channel",
@@ -4710,7 +4757,7 @@ dependencies = [
 [[package]]
 name = "net"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -4749,6 +4796,7 @@ dependencies = [
  "pixels",
  "profile_traits",
  "rayon",
+ "resvg",
  "rustls",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -4775,7 +4823,7 @@ dependencies = [
 [[package]]
 name = "net_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "compositing_traits",
@@ -4804,6 +4852,7 @@ dependencies = [
  "servo_url",
  "url",
  "uuid",
+ "webrender_api",
 ]
 
 [[package]]
@@ -5533,6 +5582,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project"
 version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5578,7 +5633,7 @@ dependencies = [
 [[package]]
 name = "pixels"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "euclid",
  "image 0.24.9",
@@ -5778,7 +5833,7 @@ dependencies = [
 [[package]]
 name = "profile"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "ipc-channel",
@@ -5797,7 +5852,7 @@ dependencies = [
 [[package]]
 name = "profile_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -5941,7 +5996,7 @@ dependencies = [
 [[package]]
 name = "range"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "malloc_size_of_derive",
  "num-traits",
@@ -6066,13 +6121,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -6114,6 +6169,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "resvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
+dependencies = [
+ "gif",
+ "image-webp",
+ "log",
+ "pico-args",
+ "rgb",
+ "svgtypes",
+ "tiny-skia",
+ "usvg",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "rfd"
 version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6142,6 +6214,9 @@ name = "rgb"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "ring"
@@ -6169,6 +6244,12 @@ dependencies = [
  "serde_derive",
  "unicode-ident",
 ]
+
+[[package]]
+name = "roxmltree"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
 name = "rustc-demangle"
@@ -6275,6 +6356,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
+name = "rustybuzz"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytemuck",
+ "core_maths",
+ "log",
+ "smallvec",
+ "ttf-parser",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-properties",
+ "unicode-script",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6304,7 +6403,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "script"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -6419,7 +6518,7 @@ dependencies = [
 [[package]]
 name = "script_bindings"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "bitflags 2.9.1",
  "crossbeam-channel",
@@ -6455,7 +6554,7 @@ dependencies = [
 [[package]]
 name = "script_layout_interface"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -6489,7 +6588,7 @@ dependencies = [
 [[package]]
 name = "script_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "background_hang_monitor_api",
  "base",
@@ -6740,7 +6839,7 @@ dependencies = [
 [[package]]
 name = "servo_allocator"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -6760,7 +6859,7 @@ dependencies = [
 [[package]]
 name = "servo_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "serde",
  "serde_json",
@@ -6772,7 +6871,7 @@ dependencies = [
 [[package]]
 name = "servo_config_macro"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6783,7 +6882,7 @@ dependencies = [
 [[package]]
 name = "servo_geometry"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "app_units",
  "euclid",
@@ -6795,7 +6894,7 @@ dependencies = [
 [[package]]
 name = "servo_malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -6808,6 +6907,8 @@ dependencies = [
  "ipc-channel",
  "keyboard-types",
  "markup5ever",
+ "mime",
+ "resvg",
  "servo_allocator",
  "servo_arc",
  "smallvec",
@@ -6830,7 +6931,7 @@ dependencies = [
 [[package]]
 name = "servo_rand"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -6844,7 +6945,7 @@ dependencies = [
 [[package]]
 name = "servo_url"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "malloc_size_of_derive",
  "serde",
@@ -6925,6 +7026,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simplecss"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a9c6883ca9c3c7c90e888de77b7a5c849c779d25d74a1269b0218b14e8b136c"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7000,12 +7110,14 @@ dependencies = [
 [[package]]
 name = "snapshot"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "euclid",
  "ipc-channel",
+ "malloc_size_of_derive",
  "pixels",
  "serde",
+ "servo_malloc_size_of",
 ]
 
 [[package]]
@@ -7075,6 +7187,9 @@ name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
 
 [[package]]
 name = "string_cache"
@@ -7301,6 +7416,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0193cc4331cfd2f3d2011ef287590868599a2f33c3e69bc22c1a3d3acf9e02fb"
 
 [[package]]
+name = "svgtypes"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68c7541fff44b35860c1a7a47a7cadf3e4a304c457b58f9870d9706ece028afc"
+dependencies = [
+ "kurbo",
+ "siphasher",
+]
+
+[[package]]
 name = "sw-composite"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7389,7 +7514,7 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 [[package]]
 name = "task_info"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "cc",
 ]
@@ -7559,7 +7684,7 @@ checksum = "06535c958d6abe68dc4b4ef9e6845f758fc42fe463d0093d0aca40254f03fb14"
 [[package]]
 name = "timers"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -7579,6 +7704,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
+ "png",
  "tiny-skia-path",
 ]
 
@@ -7612,6 +7738,21 @@ dependencies = [
  "displaydoc",
  "zerovec 0.11.2",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "to_shmem"
@@ -7825,6 +7966,9 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "tungstenite"
@@ -7938,6 +8082,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-bidi-mirroring"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7960,6 +8116,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -8027,6 +8189,33 @@ dependencies = [
  "serde",
  "unic-ucd-ident",
  "url",
+]
+
+[[package]]
+name = "usvg"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80be9b06fbae3b8b303400ab20778c80bbaf338f563afe567cf3c9eea17b47ef"
+dependencies = [
+ "base64 0.22.1",
+ "data-url",
+ "flate2",
+ "fontdb",
+ "imagesize",
+ "kurbo",
+ "log",
+ "pico-args",
+ "roxmltree",
+ "rustybuzz",
+ "simplecss",
+ "siphasher",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
 ]
 
 [[package]]
@@ -8519,7 +8708,7 @@ dependencies = [
 [[package]]
 name = "webdriver_server"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "base",
  "base64 0.22.1",
@@ -8546,7 +8735,7 @@ dependencies = [
 [[package]]
 name = "webgpu"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "arrayvec",
  "base",
@@ -8567,7 +8756,7 @@ dependencies = [
 [[package]]
 name = "webgpu_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "arrayvec",
  "base",
@@ -8666,7 +8855,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=7147e06#7147e06b53291538f7b1ead180586a3e0109f612"
+source = "git+https://github.com/servo/servo.git?rev=2d3a7c8#2d3a7c87c2887d851eddc36ce760771ae3e861df"
 dependencies = [
  "embedder_traits",
  "euclid",
@@ -9545,6 +9734,12 @@ dependencies = [
  "mac",
  "markup5ever",
 ]
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "yeslogic-fontconfig-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,32 +104,32 @@ uuid = { workspace = true }
 rfd = "0.15"
 bitflags = "2.9"
 # Servo repo crates
-background_hang_monitor = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-base = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-bluetooth = { git = "https://github.com/servo/servo.git", rev = "7147e06", optional = true }
-bluetooth_traits = { git = "https://github.com/servo/servo.git", rev = "7147e06", optional = true }
-canvas = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-compositing_traits = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-constellation = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-constellation_traits = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-devtools = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-embedder_traits = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-fonts = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-layout = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-media = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-net = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-net_traits = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-profile = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-profile_traits = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-script = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-script_traits = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-servo_allocator = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-servo_config = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-servo_geometry = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-servo_url = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-webdriver_server = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-webgpu = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
-webgpu_traits = { git = "https://github.com/servo/servo.git", rev = "7147e06" }
+background_hang_monitor = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+base = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+bluetooth = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8", optional = true }
+bluetooth_traits = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8", optional = true }
+canvas = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+compositing_traits = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+constellation = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+constellation_traits = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+devtools = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+embedder_traits = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+fonts = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+layout = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+media = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+net = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+net_traits = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+profile = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+profile_traits = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+script = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+script_traits = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+servo_allocator = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+servo_config = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+servo_geometry = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+servo_url = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+webdriver_server = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+webgpu = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
+webgpu_traits = { git = "https://github.com/servo/servo.git", rev = "2d3a7c8" }
 # Servo org crates
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }

--- a/src/window.rs
+++ b/src/window.rs
@@ -966,7 +966,12 @@ impl Window {
         #[cfg(linux)]
         {
             if let Some(icon_image) = notification.icon_resource.as_ref().and_then(|icon| {
-                Image::from_rgba(icon.width as i32, icon.height as i32, icon.bytes.to_vec()).ok()
+                Image::from_rgba(
+                    icon.metadata.width as i32,
+                    icon.metadata.height as i32,
+                    icon.bytes.to_vec(),
+                )
+                .ok()
             }) {
                 display_notification.image_data(icon_image);
             }


### PR DESCRIPTION
A notable change in this update is that Servo now supports SVGs in `img` tags and CSS `background`