### PR TITLE
Remove Mako installation from CI workflow and README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
             libharfbuzz-dev liblzma-dev libunwind-dev libvulkan1 \
             libx11-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
             libxmu-dev libxmu6 libegl1-mesa-dev llvm-dev m4 xorg-dev sway \
-            python3-mako
 
       - name: Check
         run: cargo check
@@ -105,7 +104,6 @@ jobs:
             libharfbuzz-dev liblzma-dev libunwind-dev libunwind-dev libvulkan1 \
             libx11-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
             libxmu-dev libxmu6 libegl1-mesa-dev llvm-dev m4 xorg-dev sway \
-            python3-mako
 
       - name: Check for merge group test
         if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
@@ -169,8 +167,7 @@ jobs:
       - name: Install dependencies
         run: |
           scoop install git cmake curl
-          python -m pip install mako
-
+          
       - name: Upgrade LLVM
         run: |
           choco upgrade llvm
@@ -236,7 +233,6 @@ jobs:
       - name: Install dependencies
         run: |
           brew install cmake
-          python -m pip install mako
           curl https://gstreamer.freedesktop.org/data/pkg/osx/1.24.6/gstreamer-1.0-1.24.6-universal.pkg -o runtime.pkg
           sudo installer -pkg runtime.pkg -target /
           curl https://gstreamer.freedesktop.org/data/pkg/osx/1.24.6/gstreamer-1.0-devel-1.24.6-universal.pkg -o develop.pkg

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -40,8 +40,7 @@ jobs:
             libharfbuzz-dev liblzma-dev libunwind-dev libvulkan1 \
             libx11-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
             libxmu-dev libxmu6 libegl1-mesa-dev llvm-dev m4 xorg-dev sway \
-            python3-mako
-
+            
       - name: Check
         run: cargo check
 
@@ -57,9 +56,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      - name: Install mako
-        run: python -m pip install mako
-
       - name: Check
         run: cargo check
 
@@ -74,9 +70,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
-      - name: Install mako
-        run: python -m pip install mako
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release-versoview.yml
+++ b/.github/workflows/release-versoview.yml
@@ -34,8 +34,7 @@ jobs:
             libharfbuzz-dev liblzma-dev libunwind-dev libvulkan1 \
             libx11-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
             libxmu-dev libxmu6 libegl1-mesa-dev llvm-dev m4 xorg-dev sway \
-            python3-mako
-
+            
       - name: Build
         run: cargo build --profile release-lto
 
@@ -60,9 +59,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
-      - name: Install mako
-        run: python -m pip install mako
 
       - name: Build
         run: cargo build --profile release-lto
@@ -93,9 +89,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
-      - name: Install mako
-        run: python -m pip install mako
 
       - name: Install dependencies
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,6 @@ merge_pre_check:
         libharfbuzz-dev liblzma-dev libunwind-dev libvulkan1 \
         libx11-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
         libxmu-dev libxmu6 libegl1-mesa-dev llvm-dev m4 xorg-dev sway \
-        python3-mako
     - cargo check
 
 # Check NixOS
@@ -95,7 +94,6 @@ build_linux:
           libharfbuzz-dev liblzma-dev libunwind-dev libvulkan1 \
           libx11-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev \
           libxmu-dev libxmu6 libegl1-mesa-dev llvm-dev m4 xorg-dev sway \
-          python3-mako
         cargo check || echo "Not a scheduled or manual build"
       fi
     - |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Verso is still under development. We don't accept feature requests at the moment
 
 ```sh
 scoop install git python llvm cmake curl
-pip install mako
 ```
 
 > You can also use chocolatey to install if you prefer it.
@@ -39,7 +38,6 @@ cargo run
 
 ```sh
 brew install cmake pkg-config harfbuzz
-pip install mako
 ```
 
 - Build & run:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ cargo run
 - Install [Homebrew](https://brew.sh/) and then install other tools:
 
 ```sh
-brew install cmake pkg-config harfbuzz
-pip install mako
+brew install cmake pkg-config harfbuzz mako
 ```
 
 - Build & run:

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ cargo run
 - Install [Homebrew](https://brew.sh/) and then install other tools:
 
 ```sh
-brew install cmake pkg-config harfbuzz mako
+brew install cmake pkg-config harfbuzz
+pip install mako
 ```
 
 - Build & run:

--- a/shell.nix
+++ b/shell.nix
@@ -39,7 +39,7 @@ stdenv.mkDerivation {
     mold
     wayland
     nixgl.auto.nixGLDefault
-    (python3.withPackages (ps: with ps; [pip dbus mako]))
+    (python3.withPackages (ps: with ps; [pip dbus]))
   ];
   LD_LIBRARY_PATH = lib.makeLibraryPath [
     zlib


### PR DESCRIPTION
Python package managers like pip now respect [PEP 668](https://peps.python.org/pep-0668/), which introduces the concept of an externally-managed environment.To avoid this issue and maintain a stable environment, users should install such packages using the same package manager that manages Python—in this case, Homebrew.

