### PR TITLE
Update servo to 7ab0d91

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.30"
+version = "0.2.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0f4f6fbdc5ee39f2ede9f5f3ec79477271a6d6a2baff22310d51736bda6cea"
+checksum = "e074464580a518d16a7126262fffaaa47af89d4099d4cb403f8ed938ba12ee7d"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -332,6 +332,9 @@ dependencies = [
  "serde",
  "serde_repr",
  "url",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
  "zbus",
 ]
 
@@ -349,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c74e56284d2188cabb6ad99603d1ace887a5d7e7b695d01b728155ed9ed427"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",
@@ -361,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
+checksum = "ddb939d66e4ae03cee6091612804ba446b12878410cfa17f785f4dd67d4014e8"
 dependencies = [
  "brotli",
  "flate2",
@@ -411,7 +414,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -454,7 +457,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "tracing",
 ]
 
@@ -481,7 +484,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -590,9 +593,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
+checksum = "08b5d4e069cbc868041a64bd68dc8cb39a0d79585cd6c5a24caa8c2d622121be"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -600,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
+checksum = "dbfd150b5dbdb988bcc8fb1fe787eb6b7ee6180ca24da683b61ea5405f3d43ff"
 dependencies = [
  "bindgen 0.69.5",
  "cc",
@@ -614,7 +617,7 @@ dependencies = [
 [[package]]
 name = "background_hang_monitor"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "background_hang_monitor_api",
  "backtrace",
@@ -632,7 +635,7 @@ dependencies = [
 [[package]]
 name = "background_hang_monitor_api"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "ipc-channel",
@@ -657,7 +660,7 @@ dependencies = [
 [[package]]
 name = "base"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "crossbeam-channel",
  "ipc-channel",
@@ -821,9 +824,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
 dependencies = [
  "async-channel",
  "async-task",
@@ -835,7 +838,7 @@ dependencies = [
 [[package]]
 name = "bluetooth"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "bitflags 2.9.1",
@@ -852,7 +855,7 @@ dependencies = [
 [[package]]
 name = "bluetooth_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "embedder_traits",
@@ -1022,7 +1025,7 @@ dependencies = [
 [[package]]
 name = "canvas"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "app_units",
  "canvas_traits",
@@ -1033,6 +1036,7 @@ dependencies = [
  "font-kit",
  "fonts",
  "ipc-channel",
+ "kurbo",
  "log",
  "lyon_geom",
  "net_traits",
@@ -1048,13 +1052,14 @@ dependencies = [
 [[package]]
 name = "canvas_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "crossbeam-channel",
  "euclid",
  "glow",
  "ipc-channel",
+ "kurbo",
  "malloc_size_of_derive",
  "pixels",
  "serde",
@@ -1099,9 +1104,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.27"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -1192,9 +1197,9 @@ dependencies = [
 
 [[package]]
 name = "clipboard-win"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15efe7a882b08f34e38556b14f2fb3daa98769d06c7f0c1b076dfd0d983bc892"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
 ]
@@ -1284,7 +1289,7 @@ dependencies = [
 [[package]]
 name = "compositing_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "bincode",
@@ -1325,7 +1330,7 @@ dependencies = [
 [[package]]
 name = "constellation"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "background_hang_monitor",
  "background_hang_monitor_api",
@@ -1369,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "constellation_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "canvas_traits",
@@ -1397,7 +1402,7 @@ dependencies = [
 [[package]]
 name = "content-security-policy"
 version = "0.5.4"
-source = "git+https://github.com/servo/rust-content-security-policy/?branch=servo-csp#dc1fd32b2b32b704a43f4ae170bb2cbb80a7cf59"
+source = "git+https://github.com/servo/rust-content-security-policy/?branch=servo-csp#e8d4883f9a9349e602465f31a780bc6d70b98528"
 dependencies = [
  "base64 0.22.1",
  "bitflags 2.9.1",
@@ -1501,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
@@ -1666,7 +1671,7 @@ checksum = "5c297a1c74b71ae29df00c3e22dd9534821d60eb9af5a0192823fa2acea70c2a"
 [[package]]
 name = "deny_public_fields"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "syn 2.0.104",
  "synstructure",
@@ -1716,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "devtools"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "chrono",
@@ -1739,7 +1744,7 @@ dependencies = [
 [[package]]
 name = "devtools_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "bitflags 2.9.1",
@@ -1830,23 +1835,13 @@ checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "dispatch2"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0d569e003ff27784e0e14e4a594048698e0c0f0b66cabcb51511be55a7caa0"
-dependencies = [
- "bitflags 2.9.1",
- "block2 0.6.1",
- "libc",
- "objc2 0.6.1",
-]
-
-[[package]]
-name = "dispatch2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
  "bitflags 2.9.1",
+ "block2 0.6.1",
+ "libc",
  "objc2 0.6.1",
 ]
 
@@ -1882,7 +1877,7 @@ dependencies = [
 [[package]]
 name = "dom_struct"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "quote",
  "syn 2.0.104",
@@ -1891,7 +1886,7 @@ dependencies = [
 [[package]]
 name = "domobject_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1966,7 +1961,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 [[package]]
 name = "embedder_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "cookie 0.18.1",
@@ -1982,12 +1977,14 @@ dependencies = [
  "num-traits",
  "pixels",
  "serde",
+ "servo_geometry",
  "servo_malloc_size_of",
  "servo_url",
  "strum_macros",
  "stylo",
  "stylo_traits",
  "url",
+ "uuid",
  "webdriver",
  "webrender_api",
 ]
@@ -2317,7 +2314,7 @@ dependencies = [
 [[package]]
 name = "fonts"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -2369,7 +2366,7 @@ dependencies = [
 [[package]]
 name = "fonts_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "malloc_size_of_derive",
  "range",
@@ -2884,7 +2881,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cfg_aliases",
  "cgl",
- "dispatch2 0.3.0",
+ "dispatch2",
  "glutin_egl_sys",
  "glutin_glx_sys",
  "glutin_wgl_sys",
@@ -3063,9 +3060,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -3365,7 +3362,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.26",
+ "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -3414,14 +3411,14 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
 name = "hyper-util"
-version = "0.1.14"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2fdfdbff08affe55bb779f33b053aa1fe5dd5b54c257343c17edfa55711bdb"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -3441,7 +3438,7 @@ dependencies = [
 [[package]]
 name = "hyper_serde"
 version = "0.13.2"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "cookie 0.18.1",
  "headers 0.4.1",
@@ -4264,7 +4261,7 @@ dependencies = [
 [[package]]
 name = "jstraceable_derive"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "proc-macro2",
  "syn 2.0.104",
@@ -4306,13 +4303,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1077d333efea6170d9ccb96d3c3026f300ca0773da4938cc4c811daa6df68b0c"
 dependencies = [
  "arrayvec",
+ "serde",
  "smallvec",
 ]
 
 [[package]]
 name = "layout"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -4350,6 +4348,7 @@ dependencies = [
  "servo_geometry",
  "servo_malloc_size_of",
  "servo_url",
+ "smallvec",
  "stylo",
  "stylo_atoms",
  "stylo_traits",
@@ -4364,7 +4363,7 @@ dependencies = [
 [[package]]
 name = "layout_api"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "app_units",
  "atomic_refcell",
@@ -4464,9 +4463,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -4589,9 +4588,9 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "mac-notification-sys"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1280f4ec61016b4960075c5c090085129647807a77a964bdb352c14903450589"
+checksum = "119c8490084af61b44c9eda9d626475847a186737c0378c85e32d77c33a01cd4"
 dependencies = [
  "cc",
  "objc2 0.6.1",
@@ -4669,7 +4668,7 @@ dependencies = [
 [[package]]
 name = "media"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "compositing_traits",
  "euclid",
@@ -4690,9 +4689,9 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memmap2"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
 dependencies = [
  "libc",
 ]
@@ -4738,7 +4737,7 @@ dependencies = [
 [[package]]
 name = "metrics"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "ipc-channel",
@@ -4808,7 +4807,7 @@ dependencies = [
 [[package]]
 name = "mozjs"
 version = "0.14.1"
-source = "git+https://github.com/servo/mozjs#99731e7c17ecc981fdab8f48ed45ab955966e708"
+source = "git+https://github.com/servo/mozjs#b14aebff23ac4d5b0652060ef949334bda08b22f"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -4819,8 +4818,8 @@ dependencies = [
 
 [[package]]
 name = "mozjs_sys"
-version = "0.128.9-3"
-source = "git+https://github.com/servo/mozjs#99731e7c17ecc981fdab8f48ed45ab955966e708"
+version = "0.128.13-1"
+source = "git+https://github.com/servo/mozjs#b14aebff23ac4d5b0652060ef949334bda08b22f"
 dependencies = [
  "bindgen 0.71.1",
  "cc",
@@ -4921,7 +4920,7 @@ dependencies = [
 [[package]]
 name = "net"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "async-compression",
  "async-recursion",
@@ -4959,6 +4958,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "net_traits",
+ "nom",
  "pixels",
  "profile_traits",
  "rayon",
@@ -4982,14 +4982,14 @@ dependencies = [
  "tungstenite",
  "url",
  "uuid",
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
  "webrender_api",
 ]
 
 [[package]]
 name = "net_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "compositing_traits",
@@ -5311,7 +5311,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
  "bitflags 2.9.1",
- "dispatch2 0.3.0",
+ "dispatch2",
  "objc2 0.6.1",
 ]
 
@@ -5322,7 +5322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
  "bitflags 2.9.1",
- "dispatch2 0.3.0",
+ "dispatch2",
  "objc2 0.6.1",
  "objc2-core-foundation",
  "objc2-io-surface",
@@ -5810,7 +5810,7 @@ dependencies = [
 [[package]]
 name = "pixels"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "euclid",
  "image 0.24.9",
@@ -5854,17 +5854,16 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.8.0"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
+checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.0.7",
- "tracing",
- "windows-sys 0.59.0",
+ "rustix 1.0.8",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6010,7 +6009,7 @@ dependencies = [
 [[package]]
 name = "profile"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "ipc-channel",
@@ -6029,7 +6028,7 @@ dependencies = [
 [[package]]
 name = "profile_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -6173,7 +6172,7 @@ dependencies = [
 [[package]]
 name = "range"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "malloc_size_of_derive",
  "num-traits",
@@ -6374,13 +6373,13 @@ dependencies = [
 
 [[package]]
 name = "rfd"
-version = "0.15.3"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c844748fdc82aae252ee4594a89b6e7ebef1063de7951545564cbc4e57075d"
+checksum = "ef2bee61e6cffa4635c72d7d81a84294e28f0930db0ddcb0f66d10244674ebed"
 dependencies = [
  "ashpd",
  "block2 0.6.1",
- "dispatch2 0.2.0",
+ "dispatch2",
  "js-sys",
  "log",
  "objc2 0.6.1",
@@ -6398,9 +6397,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.50"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
+checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 dependencies = [
  "bytemuck",
 ]
@@ -6480,22 +6479,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
+version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -6526,9 +6525,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6590,7 +6589,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 [[package]]
 name = "script"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -6640,6 +6639,7 @@ dependencies = [
  "itertools 0.14.0",
  "jstraceable_derive",
  "keyboard-types",
+ "kurbo",
  "layout_api",
  "libc",
  "log",
@@ -6705,7 +6705,7 @@ dependencies = [
 [[package]]
 name = "script_bindings"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "bitflags 2.9.1",
  "crossbeam-channel",
@@ -6742,7 +6742,7 @@ dependencies = [
 [[package]]
 name = "script_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "background_hang_monitor_api",
  "base",
@@ -6788,7 +6788,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.30.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#ece49719ac02599750bd15901ecd7be24e96a26a"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -6842,9 +6842,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -6900,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "servo-media"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5bc039189cc056c613251851642494b807a6715d"
+source = "git+https://github.com/servo/media#62d80f06d4f0b24eaf0cc6d523ebe5011d4fc18f"
 dependencies = [
  "once_cell",
  "servo-media-audio",
@@ -6913,7 +6913,7 @@ dependencies = [
 [[package]]
 name = "servo-media-audio"
 version = "0.2.0"
-source = "git+https://github.com/servo/media#5bc039189cc056c613251851642494b807a6715d"
+source = "git+https://github.com/servo/media#62d80f06d4f0b24eaf0cc6d523ebe5011d4fc18f"
 dependencies = [
  "byte-slice-cast",
  "euclid",
@@ -6934,7 +6934,7 @@ dependencies = [
 [[package]]
 name = "servo-media-derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5bc039189cc056c613251851642494b807a6715d"
+source = "git+https://github.com/servo/media#62d80f06d4f0b24eaf0cc6d523ebe5011d4fc18f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6944,7 +6944,7 @@ dependencies = [
 [[package]]
 name = "servo-media-dummy"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5bc039189cc056c613251851642494b807a6715d"
+source = "git+https://github.com/servo/media#62d80f06d4f0b24eaf0cc6d523ebe5011d4fc18f"
 dependencies = [
  "ipc-channel",
  "servo-media",
@@ -6958,7 +6958,7 @@ dependencies = [
 [[package]]
 name = "servo-media-player"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5bc039189cc056c613251851642494b807a6715d"
+source = "git+https://github.com/servo/media#62d80f06d4f0b24eaf0cc6d523ebe5011d4fc18f"
 dependencies = [
  "ipc-channel",
  "serde",
@@ -6970,7 +6970,7 @@ dependencies = [
 [[package]]
 name = "servo-media-streams"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5bc039189cc056c613251851642494b807a6715d"
+source = "git+https://github.com/servo/media#62d80f06d4f0b24eaf0cc6d523ebe5011d4fc18f"
 dependencies = [
  "uuid",
 ]
@@ -6978,12 +6978,12 @@ dependencies = [
 [[package]]
 name = "servo-media-traits"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5bc039189cc056c613251851642494b807a6715d"
+source = "git+https://github.com/servo/media#62d80f06d4f0b24eaf0cc6d523ebe5011d4fc18f"
 
 [[package]]
 name = "servo-media-webrtc"
 version = "0.1.0"
-source = "git+https://github.com/servo/media#5bc039189cc056c613251851642494b807a6715d"
+source = "git+https://github.com/servo/media#62d80f06d4f0b24eaf0cc6d523ebe5011d4fc18f"
 dependencies = [
  "log",
  "servo-media-streams",
@@ -6993,7 +6993,7 @@ dependencies = [
 [[package]]
 name = "servo-tracing"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7003,7 +7003,7 @@ dependencies = [
 [[package]]
 name = "servo_allocator"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -7014,7 +7014,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#ece49719ac02599750bd15901ecd7be24e96a26a"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7023,7 +7023,7 @@ dependencies = [
 [[package]]
 name = "servo_config"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "serde",
  "serde_json",
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "servo_config_macro"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7046,7 +7046,7 @@ dependencies = [
 [[package]]
 name = "servo_geometry"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "app_units",
  "euclid",
@@ -7058,7 +7058,7 @@ dependencies = [
 [[package]]
 name = "servo_malloc_size_of"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "accountable-refcell",
  "app_units",
@@ -7094,7 +7094,7 @@ dependencies = [
 [[package]]
 name = "servo_rand"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "log",
  "malloc_size_of_derive",
@@ -7108,7 +7108,7 @@ dependencies = [
 [[package]]
 name = "servo_url"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "encoding_rs",
  "malloc_size_of_derive",
@@ -7389,7 +7389,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#ece49719ac02599750bd15901ecd7be24e96a26a"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7446,7 +7446,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#ece49719ac02599750bd15901ecd7be24e96a26a"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7455,12 +7455,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#ece49719ac02599750bd15901ecd7be24e96a26a"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 
 [[package]]
 name = "stylo_derive"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#ece49719ac02599750bd15901ecd7be24e96a26a"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7472,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#ece49719ac02599750bd15901ecd7be24e96a26a"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -7481,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#ece49719ac02599750bd15901ecd7be24e96a26a"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7498,12 +7498,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#ece49719ac02599750bd15901ecd7be24e96a26a"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 
 [[package]]
 name = "stylo_traits"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#ece49719ac02599750bd15901ecd7be24e96a26a"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -7670,7 +7670,7 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 [[package]]
 name = "task_info"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "cc",
 ]
@@ -7696,7 +7696,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.7",
+ "rustix 1.0.8",
  "windows-sys 0.59.0",
 ]
 
@@ -7840,7 +7840,7 @@ checksum = "06535c958d6abe68dc4b4ef9e6845f758fc42fe463d0093d0aca40254f03fb14"
 [[package]]
 name = "timers"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "crossbeam-channel",
@@ -7913,7 +7913,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#ece49719ac02599750bd15901ecd7be24e96a26a"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#ece49719ac02599750bd15901ecd7be24e96a26a"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7937,9 +7937,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.0"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
  "bytes",
@@ -8051,7 +8051,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.11",
+ "winnow 0.7.12",
 ]
 
 [[package]]
@@ -8848,7 +8848,7 @@ dependencies = [
 [[package]]
 name = "webdriver_server"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "base",
  "base64 0.22.1",
@@ -8875,7 +8875,7 @@ dependencies = [
 [[package]]
 name = "webgpu"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "arrayvec",
  "base",
@@ -8896,7 +8896,7 @@ dependencies = [
 [[package]]
 name = "webgpu_traits"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "arrayvec",
  "base",
@@ -8915,14 +8915,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.1",
+ "webpki-roots 1.0.2",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+checksum = "7e8983c3ab33d6fb807cfcdad2491c4ea8cbc8ed839181c7dfd9c67c83e261b2"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -8995,7 +8995,7 @@ dependencies = [
 [[package]]
 name = "webxr-api"
 version = "0.0.1"
-source = "git+https://github.com/servo/servo.git?rev=3ba5b89#3ba5b89ef20575f96de7889c94eac2a6e56b8312"
+source = "git+https://github.com/servo/servo.git?rev=7ab0d91#7ab0d9110913ae4e789ff60d10dbfa588717f914"
 dependencies = [
  "embedder_traits",
  "euclid",
@@ -9704,9 +9704,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -9833,7 +9833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
- "rustix 1.0.7",
+ "rustix 1.0.8",
 ]
 
 [[package]]
@@ -9869,9 +9869,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
+checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
 
 [[package]]
 name = "xml5ever"
@@ -9950,9 +9950,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.7.1"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a7c7cee313d044fca3f48fa782cb750c79e4ca76ba7bc7718cd4024cdf6f68"
+checksum = "4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -9975,7 +9975,7 @@ dependencies = [
  "tracing",
  "uds_windows",
  "windows-sys 0.59.0",
- "winnow 0.7.11",
+ "winnow 0.7.12",
  "zbus_macros",
  "zbus_names",
  "zvariant",
@@ -9983,9 +9983,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.7.1"
+version = "5.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17e7e5eec1550f747e71a058df81a9a83813ba0f6a95f39c4e218bdc7ba366a"
+checksum = "ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -10004,7 +10004,7 @@ checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
 dependencies = [
  "serde",
  "static_assertions",
- "winnow 0.7.11",
+ "winnow 0.7.12",
  "zvariant",
 ]
 
@@ -10147,24 +10147,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.5.3"
+version = "5.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d30786f75e393ee63a21de4f9074d4c038d52c5b1bb4471f955db249f9dffb1"
+checksum = "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "url",
- "winnow 0.7.11",
+ "winnow 0.7.12",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.5.3"
+version = "5.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75fda702cd42d735ccd48117b1630432219c0e9616bf6cb0f8350844ee4d9580"
+checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
@@ -10184,5 +10184,5 @@ dependencies = [
  "serde",
  "static_assertions",
  "syn 2.0.104",
- "winnow 0.7.11",
+ "winnow 0.7.12",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,31 +104,31 @@ uuid = { workspace = true }
 rfd = "0.15"
 bitflags = "2.9"
 # Servo repo crates
-background_hang_monitor = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-base = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-bluetooth = { git = "https://github.com/servo/servo.git", rev = "3ba5b89", optional = true }
-bluetooth_traits = { git = "https://github.com/servo/servo.git", rev = "3ba5b89", optional = true }
-compositing_traits = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-constellation = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-constellation_traits = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-devtools = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-embedder_traits = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-fonts = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-layout = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-media = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-net = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-net_traits = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-profile = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-profile_traits = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-script = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-script_traits = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-servo_allocator = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-servo_config = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-servo_geometry = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-servo_url = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-webdriver_server = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-webgpu = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
-webgpu_traits = { git = "https://github.com/servo/servo.git", rev = "3ba5b89" }
+background_hang_monitor = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+base = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+bluetooth = { git = "https://github.com/servo/servo.git", rev = "7ab0d91", optional = true }
+bluetooth_traits = { git = "https://github.com/servo/servo.git", rev = "7ab0d91", optional = true }
+compositing_traits = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+constellation = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+constellation_traits = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+devtools = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+embedder_traits = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+fonts = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+layout = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+media = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+net = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+net_traits = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+profile = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+profile_traits = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+script = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+script_traits = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+servo_allocator = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+servo_config = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+servo_geometry = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+servo_url = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+webdriver_server = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+webgpu = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
+webgpu_traits = { git = "https://github.com/servo/servo.git", rev = "7ab0d91" }
 # Servo org crates
 servo-media = { git = "https://github.com/servo/media" }
 servo-media-dummy = { git = "https://github.com/servo/media" }

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -26,7 +26,7 @@ use dpi::PhysicalSize;
 use embedder_traits::{
     AnimationState, CompositorHitTestResult, Cursor, InputEvent, MouseButton, MouseButtonAction,
     MouseButtonEvent, MouseMoveEvent, TouchEvent, TouchEventType, TouchId, UntrustedNodeAddress,
-    ViewportDetails, WheelDelta, WheelEvent, WheelMode,
+    ViewportDetails,
 };
 use euclid::{Point2D, Scale, Size2D, Transform3D, Vector2D, vec2};
 use gleam::gl;
@@ -36,7 +36,7 @@ use profile_traits::mem::{ProcessReports, Report, ReportKind};
 use profile_traits::time::{self as profile_time, ProfilerCategory};
 use profile_traits::{mem, path, time, time_profile};
 use servo_config::pref;
-use servo_geometry::{DeviceIndependentIntSize, DeviceIndependentPixel};
+use servo_geometry::DeviceIndependentPixel;
 use style_traits::CSSPixel;
 use webrender::{RenderApi, Transaction};
 use webrender_api::units::{
@@ -332,10 +332,6 @@ impl PipelineDetails {
         self.scroll_tree.set_all_scroll_offsets(&old_scroll_offsets);
     }
 
-    pub(crate) fn animations_or_animation_callbacks_running(&self) -> bool {
-        self.animations_running || self.animation_callbacks_running
-    }
-
     pub(crate) fn animation_callbacks_running(&self) -> bool {
         self.animation_callbacks_running
     }
@@ -604,33 +600,6 @@ impl IOCompositor {
                 }
             }
 
-            CompositorMsg::WebDriverMouseButtonEvent(
-                webview_id,
-                action,
-                button,
-                x,
-                y,
-                webdriver_id,
-            ) => {
-                let dppx = self.device_pixels_per_page_pixel();
-                let point = dppx.transform_point(Point2D::new(x, y));
-                self.dispatch_input_event(
-                    webview_id,
-                    InputEvent::MouseButton(MouseButtonEvent::new(action, button, point))
-                        .with_webdriver_message_id(webdriver_id),
-                );
-            }
-
-            CompositorMsg::WebDriverMouseMoveEvent(webview_id, x, y, webdriver_id) => {
-                let dppx = self.device_pixels_per_page_pixel();
-                let point = dppx.transform_point(Point2D::new(x, y));
-                self.dispatch_input_event(
-                    webview_id,
-                    InputEvent::MouseMove(MouseMoveEvent::new(point))
-                        .with_webdriver_message_id(webdriver_id),
-                );
-            }
-
             CompositorMsg::SendInitialTransaction(pipeline) => {
                 let mut txn = Transaction::new();
                 txn.set_display_list(WebRenderEpoch(0), (pipeline, Default::default()));
@@ -857,62 +826,6 @@ impl IOCompositor {
                 let _ = result_sender.send((font_keys, font_instance_keys));
             }
 
-            CompositorMsg::GetClientWindowRect(_webview_id, response_sender) => {
-                // TODO: use ScreenGeometry and bring webviews to compositor. https://github.com/servo/servo/pull/36223
-                if let Err(error) =
-                    response_sender.send(self.device_independent_int_size_viewport().into())
-                {
-                    warn!("Sending response to get client window failed ({error:?}).");
-                }
-            }
-
-            CompositorMsg::GetScreenSize(_webview_id, response_sender) => {
-                // TODO: use ScreenGeometry and bring webviews to compositor. https://github.com/servo/servo/pull/36223
-                if let Err(error) =
-                    response_sender.send(self.device_independent_int_size_viewport())
-                {
-                    warn!("Sending response to get screen size failed ({error:?}).");
-                }
-            }
-
-            CompositorMsg::GetAvailableScreenSize(_webview_id, response_sender) => {
-                // TODO: use ScreenGeometry and bring webviews to compositor. https://github.com/servo/servo/pull/36223
-                if let Err(error) =
-                    response_sender.send(self.device_independent_int_size_viewport())
-                {
-                    warn!("Sending response to get screen size failed ({error:?}).");
-                }
-            }
-            CompositorMsg::WebDriverWheelScrollEvent(
-                webview_id,
-                x,
-                y,
-                delta_x,
-                delta_y,
-                message_id,
-            ) => {
-                let delta = WheelDelta {
-                    x: delta_x,
-                    y: delta_y,
-                    z: 0.0,
-                    mode: WheelMode::DeltaPixel,
-                };
-                let dppx = self.device_pixels_per_page_pixel();
-                let point = dppx.transform_point(Point2D::new(x, y));
-                let scroll_delta =
-                    dppx.transform_vector(Vector2D::new(delta_x as f32, delta_y as f32));
-
-                let scroll_location =
-                    ScrollLocation::Delta(LayoutVector2D::from_untyped(scroll_delta.to_untyped()));
-                let cursor = DeviceIntPoint::new(point.x as i32, point.y as i32);
-                self.dispatch_input_event(
-                    webview_id,
-                    InputEvent::Wheel(WheelEvent::new(delta, point))
-                        .with_webdriver_message_id(message_id),
-                );
-                self.on_scroll_window_event(scroll_location, cursor);
-            }
-
             CompositorMsg::Viewport(_webview_id, viewport_description) => {
                 self.pending_scroll_zoom_events
                     .push(ScrollZoomEvent::ViewportZoom(
@@ -956,21 +869,6 @@ impl IOCompositor {
                     .map(|_| self.webrender_api.generate_font_instance_key())
                     .collect();
                 let _ = result_sender.send((font_keys, font_instance_keys));
-            }
-            CompositorMsg::GetClientWindowRect(_, response_sender) => {
-                if let Err(error) = response_sender.send(Default::default()) {
-                    warn!("Sending response to get client window failed ({error:?}).");
-                }
-            }
-            CompositorMsg::GetScreenSize(_, response_sender) => {
-                if let Err(error) = response_sender.send(Default::default()) {
-                    warn!("Sending response to get client window failed ({error:?}).");
-                }
-            }
-            CompositorMsg::GetAvailableScreenSize(_, response_sender) => {
-                if let Err(error) = response_sender.send(Default::default()) {
-                    warn!("Sending response to get client window failed ({error:?}).");
-                }
             }
             CompositorMsg::NewWebRenderFrameReady(..) => {
                 // Subtract from the number of pending frames, but do not do any compositing.
@@ -1954,10 +1852,6 @@ impl IOCompositor {
         Scale::new(self.scale_factor.get())
     }
 
-    fn device_independent_int_size_viewport(&self) -> DeviceIndependentIntSize {
-        (self.viewport.to_f32() / self.scale_factor).to_i32()
-    }
-
     /// Handle zoom reset event
     pub fn on_zoom_reset_window_event(&mut self, window: &Window) {
         if self.shutdown_state != ShutdownState::NotShuttingDown {
@@ -2020,13 +1914,6 @@ impl IOCompositor {
                 pipeline_id,
                 scroll_offsets,
             ));
-    }
-
-    // Check if any pipelines currently have active animations or animation callbacks.
-    fn animations_or_animation_callbacks_running(&self) -> bool {
-        self.pipeline_details
-            .values()
-            .any(PipelineDetails::animations_or_animation_callbacks_running)
     }
 
     /// Returns true if any animation callbacks (ie `requestAnimationFrame`) are waiting for a response.
@@ -2125,15 +2012,6 @@ impl IOCompositor {
         let wait_for_stable_image = self.wait_for_stable_image;
 
         if wait_for_stable_image {
-            // The current image may be ready to output. However, if there are animations active,
-            // tick those instead and continue waiting for the image output to be stable AND
-            // all active animations to complete.
-            if self.animations_or_animation_callbacks_running() {
-                self.process_animations(false);
-                return Err(UnableToComposite::NotReadyToPaintImage(
-                    NotReadyToPaint::AnimationsActive,
-                ));
-            }
             if let Err(result) = self.is_ready_to_paint_image_output() {
                 return Err(UnableToComposite::NotReadyToPaintImage(result));
             }
@@ -2351,7 +2229,6 @@ enum UnableToComposite {
 
 #[derive(Debug, PartialEq)]
 enum NotReadyToPaint {
-    AnimationsActive,
     JustNotifiedConstellation,
     WaitingOnConstellation,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,6 +47,8 @@ pub struct CliArgs {
     pub no_maximized: bool,
     /// Port number to start a server to listen to remote Firefox devtools connections. 0 for random port.
     pub devtools_port: Option<u16>,
+    /// Start remote WebDriver server on port
+    pub webdriver_port: Option<u16>,
     /// Servo time profile settings
     pub profiler_settings: Option<versoview_messages::ProfilerSettings>,
     /// Path to resource directory. If None, Verso will try to get default directory. And if that
@@ -81,6 +83,12 @@ pub fn parse_cli_args() -> Result<CliArgs, getopts::Fail> {
         "devtools-port",
         "Launch Verso with devtools server enabled and listen to port",
         "1234",
+    );
+    opts.optopt(
+        "",
+        "webdriver-port",
+        "Start remote WebDriver server on port",
+        "7000",
     );
     opts.optopt(
         "p",
@@ -174,6 +182,12 @@ pub fn parse_cli_args() -> Result<CliArgs, getopts::Fail> {
         log::error!("Failed to parse devtools-port command line argument: {e}");
         None
     });
+    let webdriver_port = matches
+        .opt_get::<u16>("webdriver-port")
+        .unwrap_or_else(|e| {
+            log::error!("Failed to parse webdriver-port command line argument: {e}");
+            None
+        });
 
     let profiler_settings = if let Ok(Some(profiler_interval)) = matches.opt_get("profiler") {
         let profile_output = matches.opt_str("profiler-output-file");
@@ -249,6 +263,7 @@ pub fn parse_cli_args() -> Result<CliArgs, getopts::Fail> {
         ipc_channel,
         no_panel,
         devtools_port,
+        webdriver_port,
         profiler_settings,
         user_agent,
         init_script,
@@ -271,6 +286,8 @@ pub struct Config {
     pub window_attributes: WindowAttributes,
     /// Port number to start a server to listen to remote Firefox devtools connections. 0 for random port.
     pub devtools_port: Option<u16>,
+    /// Start remote WebDriver server on port
+    pub webdriver_port: Option<u16>,
     /// Servo time profile settings
     pub profiler_settings: Option<ProfilerSettings>,
     /// Override the user agent
@@ -375,6 +392,7 @@ impl Config {
             with_panel,
             window_attributes,
             devtools_port: config.devtools_port,
+            webdriver_port: config.webdriver_port,
             profiler_settings,
             user_agent,
             user_scripts: config

--- a/src/javascript_evaluator.rs
+++ b/src/javascript_evaluator.rs
@@ -1,0 +1,83 @@
+// Modified from https://github.com/servo/servo/blob/7ab0d9110913ae4e789ff60d10dbfa588717f914/components/servo/javascript_evaluator.rs
+
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+use std::collections::HashMap;
+
+use base::id::WebViewId;
+use constellation_traits::EmbedderToConstellationMessage;
+use crossbeam_channel::Sender;
+use embedder_traits::{JSValue, JavaScriptEvaluationError, JavaScriptEvaluationId};
+
+use crate::verso::send_to_constellation;
+
+struct PendingEvaluation {
+    callback: Box<dyn FnOnce(Result<JSValue, JavaScriptEvaluationError>)>,
+}
+
+pub struct JavaScriptEvaluator {
+    current_id: JavaScriptEvaluationId,
+    pending_evaluations: HashMap<JavaScriptEvaluationId, PendingEvaluation>,
+}
+
+impl JavaScriptEvaluator {
+    pub fn new() -> Self {
+        Self {
+            current_id: JavaScriptEvaluationId(0),
+            pending_evaluations: Default::default(),
+        }
+    }
+
+    fn generate_id(&mut self) -> JavaScriptEvaluationId {
+        let next_id = JavaScriptEvaluationId(self.current_id.0 + 1);
+        std::mem::replace(&mut self.current_id, next_id)
+    }
+
+    pub fn evaluate(
+        &mut self,
+        constellation_sender: &Sender<EmbedderToConstellationMessage>,
+        webview_id: &WebViewId,
+        js: impl Into<String>,
+        callback: Box<dyn FnOnce(Result<JSValue, JavaScriptEvaluationError>)>,
+    ) {
+        let evaluation_id = self.generate_id();
+        send_to_constellation(
+            constellation_sender,
+            EmbedderToConstellationMessage::EvaluateJavaScript(
+                *webview_id,
+                evaluation_id,
+                js.into(),
+            ),
+        );
+        self.pending_evaluations
+            .insert(evaluation_id, PendingEvaluation { callback });
+    }
+
+    pub fn evaluate_ignore_result(
+        &mut self,
+        constellation_sender: &Sender<EmbedderToConstellationMessage>,
+        webview_id: &WebViewId,
+        js: impl Into<String>,
+    ) {
+        self.evaluate(
+            constellation_sender,
+            webview_id,
+            js.into(),
+            Box::new(|_| {}),
+        );
+    }
+
+    pub fn finish_evaluation(
+        &mut self,
+        evaluation_id: JavaScriptEvaluationId,
+        result: Result<JSValue, JavaScriptEvaluationError>,
+    ) {
+        (self
+            .pending_evaluations
+            .remove(&evaluation_id)
+            .expect("Received request to finish unknown JavaScript evaluation.")
+            .callback)(result)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub mod compositor;
 pub mod config;
 /// Error and result types.
 pub mod errors;
+mod javascript_evaluator;
 /// Utilities to handle keyboard inputs and states.
 pub mod keyboard;
 /// Verso's rendering context.

--- a/src/verso.rs
+++ b/src/verso.rs
@@ -46,7 +46,7 @@ use crate::{
     bookmark::BookmarkManager,
     compositor::{IOCompositor, InitialCompositorState, ShutdownState},
     config::{Config, parse_cli_args, to_winit_theme, to_winit_window_level},
-    webview::execute_script,
+    javascript_evaluator::JavaScriptEvaluator,
     window::Window,
 };
 
@@ -66,6 +66,7 @@ pub struct Verso {
     clipboard: Option<Clipboard>,
     config: Config,
     bookmark_manager: BookmarkManager,
+    javascript_evaluator: JavaScriptEvaluator,
 }
 
 impl Verso {
@@ -330,10 +331,16 @@ impl Verso {
             compositor.on_zoom_window_event(zoom_level, &window);
         }
 
+        let mut javascript_evaluator = JavaScriptEvaluator::new();
+
         if with_panel {
             window.create_panel(&constellation_sender, initial_url);
         } else {
-            window.create_tab(&constellation_sender, initial_url.into());
+            window.create_tab(
+                &constellation_sender,
+                initial_url.into(),
+                &mut javascript_evaluator,
+            );
         }
 
         let mut windows = HashMap::new();
@@ -351,6 +358,7 @@ impl Verso {
             clipboard: Clipboard::new().ok(),
             config,
             bookmark_manager: BookmarkManager::new(),
+            javascript_evaluator,
         };
 
         verso.setup_logging();
@@ -421,7 +429,12 @@ impl Verso {
             // self.windows.remove(&window_id);
             compositor.start_shutting_down();
         } else {
-            window.handle_winit_window_event(&self.constellation_sender, compositor, &event);
+            window.handle_winit_window_event(
+                &self.constellation_sender,
+                compositor,
+                &event,
+                &mut self.javascript_evaluator,
+            );
             return window.resizing;
         }
 
@@ -457,6 +470,7 @@ impl Verso {
                         self.clipboard.as_mut(),
                         compositor,
                         &mut self.bookmark_manager,
+                        &mut self.javascript_evaluator,
                     ) {
                         let mut window = Window::new_with_compositor(
                             evl,
@@ -488,6 +502,10 @@ impl Verso {
                                 "Failed to send RequestDevtoolsConnection response back: {err}"
                             );
                         }
+                    }
+                    EmbedderMsg::FinishJavaScriptEvaluation(evaluation_id, result) => {
+                        self.javascript_evaluator
+                            .finish_evaluation(evaluation_id, result);
                     }
                     EmbedderMsg::ShutdownComplete => {
                         compositor.finish_shutting_down();
@@ -678,7 +696,11 @@ impl Verso {
             }
             ToVersoMessage::ExecuteScript(js) => {
                 if let Some(webview_id) = self.first_webview_id() {
-                    let _ = execute_script(&self.constellation_sender, &webview_id, js);
+                    self.javascript_evaluator.evaluate_ignore_result(
+                        &self.constellation_sender,
+                        &webview_id,
+                        js,
+                    );
                 }
             }
             ToVersoMessage::ListenToWebResourceRequests => {

--- a/src/verso.rs
+++ b/src/verso.rs
@@ -279,13 +279,25 @@ impl Verso {
             );
 
         // Create webdriver thread
-        let webdriver_receiver = if let Some(port) = opts.webdriver_port {
+        let webdriver_receiver = if let Some(port) = config.webdriver_port {
             let (embedder_sender, embedder_receiver) = unbounded();
+            let (webdriver_response_sender, webdriver_response_receiver) = ipc::channel().unwrap();
+
+            // Set the WebDriver response sender to constellation.
+            // TODO: consider using Servo API to notify embedder about input events completions
+            constellation_sender
+                .send(EmbedderToConstellationMessage::SetWebDriverResponseSender(
+                    webdriver_response_sender,
+                ))
+                .unwrap_or_else(|_| {
+                    log::warn!("Failed to set WebDriver response sender in constellation");
+                });
             webdriver_server::start_server(
                 port,
                 constellation_sender.clone(),
                 embedder_sender,
                 event_loop_waker.clone(),
+                webdriver_response_receiver,
             );
             Some(embedder_receiver)
         } else {
@@ -563,7 +575,9 @@ impl Verso {
             EmbedderMsg::ShowFormControl(webview_id, ..) => Some(webview_id),
             EmbedderMsg::ShutdownComplete => None,
             EmbedderMsg::FinishJavaScriptEvaluation(..) => None,
-            EmbedderMsg::WebDriverCommand(..) => None,
+            EmbedderMsg::HistoryTraversalComplete(webview_id, ..) => Some(webview_id),
+            EmbedderMsg::GetWindowRect(webview_id, ..) => Some(webview_id),
+            EmbedderMsg::GetScreenMetrics(webview_id, ..) => Some(webview_id),
         }
     }
 

--- a/src/webview/context_menu.rs
+++ b/src/webview/context_menu.rs
@@ -347,6 +347,7 @@ impl Window {
                             EmbedderToConstellationMessage::TraverseHistory(
                                 tab_id,
                                 TraversalDirection::Back(1),
+                                TraversalId::new(),
                             ),
                         );
                     }
@@ -356,6 +357,7 @@ impl Window {
                             EmbedderToConstellationMessage::TraverseHistory(
                                 tab_id,
                                 TraversalDirection::Forward(1),
+                                TraversalId::new(),
                             ),
                         );
                     }

--- a/src/webview/context_menu.rs
+++ b/src/webview/context_menu.rs
@@ -1,9 +1,9 @@
 use crate::verso::send_to_constellation;
 use crate::window::Window;
 use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
-use embedder_traits::ContextMenuResult;
 #[cfg(linux)]
 use embedder_traits::ViewportDetails;
+use embedder_traits::{ContextMenuResult, TraversalId};
 use ipc_channel::ipc::IpcSender;
 
 /* macOS, Windows Native Implementation */
@@ -304,6 +304,7 @@ impl Window {
                     EmbedderToConstellationMessage::TraverseHistory(
                         active_tab.id(),
                         TraversalDirection::Back(1),
+                        TraversalId::new(),
                     ),
                 );
             }
@@ -313,6 +314,7 @@ impl Window {
                     EmbedderToConstellationMessage::TraverseHistory(
                         active_tab.id(),
                         TraversalDirection::Forward(1),
+                        TraversalId::new(),
                     ),
                 );
             }

--- a/src/webview/history_menu.rs
+++ b/src/webview/history_menu.rs
@@ -4,7 +4,7 @@ use crate::{verso::send_to_constellation, window::Window};
 use base::id::WebViewId;
 use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use crossbeam_channel::Sender;
-use embedder_traits::ViewportDetails;
+use embedder_traits::{TraversalId, ViewportDetails};
 use serde::{Deserialize, Serialize};
 use servo_url::ServoUrl;
 use std::fmt;
@@ -202,6 +202,7 @@ impl Window {
                             EmbedderToConstellationMessage::TraverseHistory(
                                 tab_id,
                                 TraversalDirection::Back(index + 1),
+                                TraversalId::new(),
                             ),
                         );
                     }
@@ -211,6 +212,7 @@ impl Window {
                             EmbedderToConstellationMessage::TraverseHistory(
                                 tab_id,
                                 TraversalDirection::Forward(index + 1),
+                                TraversalId::new(),
                             ),
                         );
                     }

--- a/src/webview/mod.rs
+++ b/src/webview/mod.rs
@@ -1,6 +1,6 @@
 mod webview;
 /// WebView
-pub use webview::{Panel, WebView, execute_script};
+pub use webview::{Panel, WebView};
 /// Context Menu
 pub mod context_menu;
 /// Browsing history menu

--- a/src/webview/webview.rs
+++ b/src/webview/webview.rs
@@ -4,8 +4,8 @@ use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use crossbeam_channel::Sender;
 use embedder_traits::{
     AlertResponse, AllowOrDeny, ConfirmResponse, ContextMenuResult, EmbedderMsg, LoadStatus,
-    PromptResponse, SimpleDialog, ViewportDetails, WebDriverCommandMsg, WebDriverJSResult,
-    WebDriverScriptCommand,
+    PromptResponse, SimpleDialog, TraversalId, ViewportDetails, WebDriverCommandMsg,
+    WebDriverJSResult, WebDriverScriptCommand,
 };
 use euclid::Scale;
 use ipc_channel::ipc;
@@ -644,6 +644,7 @@ impl Window {
                                             EmbedderToConstellationMessage::TraverseHistory(
                                                 id,
                                                 TraversalDirection::Back(1),
+                                                TraversalId::new(),
                                             ),
                                         );
                                         // TODO Set EmbedderMsg::Status to None
@@ -654,6 +655,7 @@ impl Window {
                                             EmbedderToConstellationMessage::TraverseHistory(
                                                 id,
                                                 TraversalDirection::Forward(1),
+                                                TraversalId::new(),
                                             ),
                                         );
                                         // TODO Set EmbedderMsg::Status to None

--- a/src/webview/webview.rs
+++ b/src/webview/webview.rs
@@ -4,8 +4,7 @@ use constellation_traits::{EmbedderToConstellationMessage, TraversalDirection};
 use crossbeam_channel::Sender;
 use embedder_traits::{
     AlertResponse, AllowOrDeny, ConfirmResponse, ContextMenuResult, EmbedderMsg, LoadStatus,
-    PromptResponse, SimpleDialog, TraversalId, ViewportDetails, WebDriverCommandMsg,
-    WebDriverJSResult, WebDriverScriptCommand,
+    PromptResponse, SimpleDialog, TraversalId, ViewportDetails,
 };
 use euclid::Scale;
 use ipc_channel::ipc;
@@ -17,6 +16,7 @@ use webrender_api::units::{DevicePoint, DeviceRect};
 use crate::{
     bookmark::BookmarkManager,
     compositor::IOCompositor,
+    javascript_evaluator::JavaScriptEvaluator,
     tab::{TabActivateRequest, TabCloseRequest, TabCreateResponse},
     verso::send_to_constellation,
     webview::{
@@ -83,6 +83,7 @@ impl Window {
         to_controller_sender: &Option<ipc::IpcSender<ToControllerMessage>>,
         clipboard: Option<&mut Clipboard>,
         compositor: &mut IOCompositor,
+        javascript_evaluator: &mut JavaScriptEvaluator,
     ) {
         log::trace!("Verso WebView {webview_id:?} is handling Embedder message: {message:?}",);
         match message {
@@ -132,7 +133,11 @@ impl Window {
                         serde_json::to_string(&webview_id).unwrap(),
                         title.as_str()
                     );
-                    let _ = execute_script(sender, &panel.webview.webview_id, script);
+                    javascript_evaluator.evaluate_ignore_result(
+                        sender,
+                        &panel.webview.webview_id,
+                        script,
+                    );
                 }
             }
             EmbedderMsg::AllowNavigationRequest(_webview_id, id, url) => {
@@ -233,12 +238,12 @@ impl Window {
                 let prev_btn_enabled = index > 0;
                 let next_btn_enabled = index < list.len() - 1;
                 if let Some(panel) = self.panel.as_ref() {
-                    let _ = execute_script(
+                    javascript_evaluator.evaluate_ignore_result(
                         sender,
                         &panel.webview.webview_id,
                         format!("window.navbar.setNavbarUrl('{}')", url.as_str()),
                     );
-                    let _ = execute_script(
+                    javascript_evaluator.evaluate_ignore_result(
                         sender,
                         &panel.webview.webview_id,
                         format!(
@@ -418,6 +423,7 @@ impl Window {
         clipboard: Option<&mut Clipboard>,
         compositor: &mut IOCompositor,
         bookmark_manager: &mut BookmarkManager,
+        javascript_evaluator: &mut JavaScriptEvaluator,
     ) -> bool {
         log::trace!("Verso Panel {panel_id:?} is handling Embedder message: {message:?}",);
         match message {
@@ -448,7 +454,11 @@ impl Window {
                         EmbedderToConstellationMessage::FocusWebView(panel_id),
                     );
 
-                    self.create_tab(sender, self.panel.as_ref().unwrap().initial_url.clone());
+                    self.create_tab(
+                        sender,
+                        self.panel.as_ref().unwrap().initial_url.clone(),
+                        javascript_evaluator,
+                    );
                 }
             },
             EmbedderMsg::AllowNavigationRequest(_webview_id, id, _url) => {
@@ -494,7 +504,12 @@ impl Window {
                             let _ = response_sender.send(PromptResponse::default());
 
                             // FIXME: set dirty flag, and only resize when flag is set
-                            self.activate_tab(compositor, tab_id, self.tab_manager.count() > 1);
+                            self.activate_tab(
+                                compositor,
+                                tab_id,
+                                self.tab_manager.count() > 1,
+                                javascript_evaluator,
+                            );
 
                             return false;
                         } else if message == "NEW_TAB" {
@@ -591,7 +606,7 @@ impl Window {
                                                 .unwrap()
                                         );
                                         if let Some(panel) = self.panel.as_ref() {
-                                            let _ = execute_script(
+                                            javascript_evaluator.evaluate_ignore_result(
                                                 sender,
                                                 &panel.webview.webview_id,
                                                 script,
@@ -891,21 +906,4 @@ impl Window {
         }
         false
     }
-}
-
-/// Blocking execute a script on this webview
-pub fn execute_script(
-    constellation_sender: &Sender<EmbedderToConstellationMessage>,
-    webview: &WebViewId,
-    js: impl ToString,
-) -> WebDriverJSResult {
-    let (result_sender, result_receiver) = ipc::channel::<WebDriverJSResult>().unwrap();
-    send_to_constellation(
-        constellation_sender,
-        EmbedderToConstellationMessage::WebDriverCommand(WebDriverCommandMsg::ScriptCommand(
-            webview.0,
-            WebDriverScriptCommand::ExecuteScript(js.to_string(), result_sender),
-        )),
-    );
-    result_receiver.recv().unwrap()
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -6,7 +6,7 @@ use crossbeam_channel::Sender;
 use embedder_traits::{
     AlertResponse, AllowOrDeny, ConfirmResponse, Cursor, EmbedderMsg, ImeEvent, InputEvent,
     MouseButton, MouseButtonAction, MouseButtonEvent, MouseLeaveEvent, MouseMoveEvent,
-    Notification, PromptResponse, TouchEventType, ViewportDetails, WebDriverJSValue,
+    Notification, PromptResponse, ScreenMetrics, TouchEventType, ViewportDetails, WebDriverJSValue,
     WebResourceResponseMsg, WheelMode,
 };
 use euclid::{Point2D, Scale, Size2D};
@@ -25,6 +25,7 @@ use muda::{MenuEvent, MenuEventReceiver};
 use notify_rust::Image;
 #[cfg(target_os = "macos")]
 use raw_window_handle::HasWindowHandle;
+use servo_geometry::convert_size_to_css_pixel;
 use servo_url::ServoUrl;
 use versoview_messages::ToControllerMessage;
 use webrender_api::{
@@ -734,9 +735,45 @@ impl Window {
         compositor: &mut IOCompositor,
         bookmark_manager: &mut BookmarkManager,
     ) -> bool {
-        if let EmbedderMsg::SetCursor(_, cursor) = message {
-            self.set_cursor_icon(cursor);
-            return false;
+        match message {
+            EmbedderMsg::SetCursor(_, cursor) => {
+                self.set_cursor_icon(cursor);
+                return false;
+            }
+            EmbedderMsg::GetScreenMetrics(_, response_sender) => {
+                let screen_size = self
+                    .window
+                    .current_monitor()
+                    .map(|monitor| monitor.size().cast())
+                    .unwrap_or_default();
+                let scale_factor = self.window.scale_factor() as f32;
+                // let toolbar_size = Size2D::new(
+                //     0.0,
+                //     (self.toolbar_height.get() * self.hidpi_scale_factor()).0,
+                // );
+                // let screen_size = self.screen_size.to_f32() * hidpi_factor;
+
+                // // FIXME: In reality, this should subtract screen space used by the system interface
+                // // elements, but it is difficult to get this value with `winit` currently. See:
+                // // See https://github.com/rust-windowing/winit/issues/2494
+                // let available_screen_size = screen_size - toolbar_size;
+
+                let screen_metrics = ScreenMetrics {
+                    screen_size: convert_size_to_css_pixel(
+                        Size2D::new(screen_size.width, screen_size.height),
+                        Scale::new(scale_factor),
+                    ),
+                    available_size: convert_size_to_css_pixel(
+                        Size2D::new(screen_size.width, screen_size.height),
+                        Scale::new(scale_factor),
+                    ),
+                };
+                if let Err(error) = response_sender.send(screen_metrics) {
+                    log::error!("Failed to respond to GetScreenMetrics: {error}");
+                }
+                return false;
+            }
+            _ => {}
         }
 
         // Handle message in Verso Panel

--- a/src/window.rs
+++ b/src/window.rs
@@ -6,7 +6,7 @@ use crossbeam_channel::Sender;
 use embedder_traits::{
     AlertResponse, AllowOrDeny, ConfirmResponse, Cursor, EmbedderMsg, ImeEvent, InputEvent,
     MouseButton, MouseButtonAction, MouseButtonEvent, MouseLeaveEvent, MouseMoveEvent,
-    Notification, PromptResponse, ScreenMetrics, TouchEventType, ViewportDetails, WebDriverJSValue,
+    Notification, PromptResponse, ScreenMetrics, TouchEventType, ViewportDetails,
     WebResourceResponseMsg, WheelMode,
 };
 use euclid::{Point2D, Scale, Size2D};
@@ -48,11 +48,12 @@ use winit::{
 use crate::{
     bookmark::BookmarkManager,
     compositor::IOCompositor,
+    javascript_evaluator::JavaScriptEvaluator,
     keyboard::keyboard_event_from_winit,
     rendering::{RenderingContext, gl_config_picker},
     tab::TabManager,
     verso::send_to_constellation,
-    webview::{Panel, WebView, execute_script, prompt::PromptSender, webview_menu::WebViewMenu},
+    webview::{Panel, WebView, prompt::PromptSender, webview_menu::WebViewMenu},
 };
 
 use arboard::Clipboard;
@@ -274,6 +275,7 @@ impl Window {
         &mut self,
         constellation_sender: &Sender<EmbedderToConstellationMessage>,
         initial_url: ServoUrl,
+        javascript_evaluator: &mut JavaScriptEvaluator,
     ) {
         let webview_id = WebViewId::new();
         let size = self.size().to_f32();
@@ -299,7 +301,11 @@ impl Window {
                 true,
             );
 
-            let _ = execute_script(constellation_sender, &panel.webview.webview_id, cmd);
+            javascript_evaluator.evaluate_ignore_result(
+                constellation_sender,
+                &panel.webview.webview_id,
+                cmd,
+            );
         }
 
         self.tab_manager.append_tab(webview, true);
@@ -312,26 +318,26 @@ impl Window {
     }
 
     /// Close a tab
-    pub fn close_tab(&mut self, compositor: &mut IOCompositor, tab_id: WebViewId) {
+    pub fn close_tab(
+        &mut self,
+        compositor: &mut IOCompositor,
+        tab_id: WebViewId,
+        javascript_evaluator: &mut JavaScriptEvaluator,
+    ) {
         // if there are more than 2 tabs, we need to ask for the new active tab after tab is closed
         if self.tab_manager.count() > 1 {
             if let Some(panel) = &self.panel {
                 let cmd: String = format!(
-                    "window.navbar.closeTab('{}')",
+                    "const nextTab = window.navbar.closeTab('{}');",
                     serde_json::to_string(&tab_id).unwrap()
                 );
+                let activate_next_tab = r#"if (nextTab) window.prompt(`ACTIVATE_TAB:${JSON.stringify({ id: nextTab })}`)"#;
 
-                let active_tab_id = execute_script(
+                javascript_evaluator.evaluate_ignore_result(
                     &compositor.constellation_chan,
                     &panel.webview.webview_id,
-                    cmd,
-                )
-                .unwrap();
-
-                if let WebDriverJSValue::String(resp) = active_tab_id {
-                    let active_id: WebViewId = serde_json::from_str(&resp).unwrap();
-                    self.activate_tab(compositor, active_id, self.tab_manager.count() > 2);
-                }
+                    format!("{cmd}{activate_next_tab}"),
+                );
             }
         }
         send_to_constellation(
@@ -346,6 +352,7 @@ impl Window {
         compositor: &mut IOCompositor,
         tab_id: WebViewId,
         show_tab: bool,
+        javascript_evaluator: &mut JavaScriptEvaluator,
     ) {
         let size = self.size().to_f32();
         let rect = DeviceRect::from_size(size);
@@ -379,7 +386,7 @@ impl Window {
                 let history = self.tab_manager.history(tab_id).unwrap();
                 let prev_btn_enabled = history.current_idx > 0;
                 let next_btn_enabled = history.current_idx < history.list.len() - 1;
-                let _ = execute_script(
+                javascript_evaluator.evaluate_ignore_result(
                     &compositor.constellation_chan,
                     &self.panel.as_ref().unwrap().webview.webview_id,
                     format!(
@@ -400,6 +407,7 @@ impl Window {
         sender: &Sender<EmbedderToConstellationMessage>,
         compositor: &mut IOCompositor,
         event: &winit::event::WindowEvent,
+        javascript_evaluator: &mut JavaScriptEvaluator,
     ) {
         match event {
             WindowEvent::RedrawRequested => {
@@ -661,7 +669,7 @@ impl Window {
                 log::trace!("Verso is handling {:?}", event);
 
                 /* Window operation keyboard shortcut */
-                if self.handle_keyboard_shortcut(compositor, &event) {
+                if self.handle_keyboard_shortcut(compositor, &event, javascript_evaluator) {
                     return;
                 }
                 forward_input_event(
@@ -696,6 +704,7 @@ impl Window {
         &mut self,
         compositor: &mut IOCompositor,
         event: &KeyboardEvent,
+        javascript_evaluator: &mut JavaScriptEvaluator,
     ) -> bool {
         let is_macos = cfg!(target_os = "macos");
         let control_or_meta = if is_macos {
@@ -711,12 +720,13 @@ impl Window {
                     (*self).create_tab(
                         &compositor.constellation_chan,
                         ServoUrl::parse("https://example.com").unwrap(),
+                        javascript_evaluator,
                     );
                     return true;
                 }
                 (modifiers, Code::KeyW) if modifiers == control_or_meta => {
                     if let Some(tab_id) = self.tab_manager.current_tab_id() {
-                        (*self).close_tab(compositor, tab_id);
+                        (*self).close_tab(compositor, tab_id, javascript_evaluator);
                     }
                     return true;
                 }
@@ -737,6 +747,7 @@ impl Window {
         clipboard: Option<&mut Clipboard>,
         compositor: &mut IOCompositor,
         bookmark_manager: &mut BookmarkManager,
+        javascript_evaluator: &mut JavaScriptEvaluator,
     ) -> bool {
         match message {
             EmbedderMsg::SetCursor(_, cursor) => {
@@ -808,6 +819,7 @@ impl Window {
                     clipboard,
                     compositor,
                     bookmark_manager,
+                    javascript_evaluator,
                 );
             }
         }
@@ -834,6 +846,7 @@ impl Window {
             to_controller_sender,
             clipboard,
             compositor,
+            javascript_evaluator,
         );
         false
     }

--- a/src/window.rs
+++ b/src/window.rs
@@ -25,12 +25,15 @@ use muda::{MenuEvent, MenuEventReceiver};
 use notify_rust::Image;
 #[cfg(target_os = "macos")]
 use raw_window_handle::HasWindowHandle;
-use servo_geometry::convert_size_to_css_pixel;
+use servo_geometry::{convert_rect_to_css_pixel, convert_size_to_css_pixel};
 use servo_url::ServoUrl;
 use versoview_messages::ToControllerMessage;
 use webrender_api::{
     ScrollLocation,
-    units::{DeviceIntPoint, DevicePixel, DevicePoint, DeviceRect, DeviceSize, LayoutVector2D},
+    units::{
+        DeviceIntPoint, DeviceIntRect, DevicePixel, DevicePoint, DeviceRect, DeviceSize,
+        LayoutVector2D,
+    },
 };
 #[cfg(any(linux, target_os = "windows"))]
 use winit::window::ResizeDirection;
@@ -740,13 +743,32 @@ impl Window {
                 self.set_cursor_icon(cursor);
                 return false;
             }
+            EmbedderMsg::GetWindowRect(_, response_sender) => {
+                let scale_factor = self.window.scale_factor() as f32;
+                let position = self.window.outer_position().unwrap_or_default();
+                let size = self.window.outer_size();
+                let window_rect = DeviceIntRect::from_origin_and_size(
+                    Point2D::new(position.x, position.y),
+                    Size2D::new(size.width, size.height).to_i32(),
+                );
+                if let Err(error) = response_sender.send(convert_rect_to_css_pixel(
+                    window_rect,
+                    Scale::new(scale_factor),
+                )) {
+                    log::error!("Failed to respond to GetWindowRect: {error}");
+                }
+                return false;
+            }
             EmbedderMsg::GetScreenMetrics(_, response_sender) => {
-                let screen_size = self
-                    .window
-                    .current_monitor()
+                let monitor = self.window.current_monitor();
+                let screen_size = monitor
+                    .as_ref()
                     .map(|monitor| monitor.size().cast())
                     .unwrap_or_default();
-                let scale_factor = self.window.scale_factor() as f32;
+                let scale_factor = monitor
+                    .as_ref()
+                    .map(|monitor| monitor.scale_factor() as f32)
+                    .unwrap_or_default();
                 // let toolbar_size = Size2D::new(
                 //     0.0,
                 //     (self.toolbar_height.get() * self.hidpi_scale_factor()).0,

--- a/verso/src/builder.rs
+++ b/verso/src/builder.rs
@@ -99,6 +99,12 @@ impl VersoBuilder {
         self
     }
 
+    /// Start remote WebDriver server on port
+    pub fn webdriver_port(mut self, port: u16) -> Self {
+        self.0.webdriver_port = Some(port);
+        self
+    }
+
     /// Sets the profiler settings.
     pub fn profiler_settings(mut self, settings: ProfilerSettings) -> Self {
         self.0.profiler_settings = Some(settings);

--- a/verso/src/lib.rs
+++ b/verso/src/lib.rs
@@ -221,8 +221,12 @@ impl VersoviewController {
     }
 
     /// Execute script
-    pub fn execute_script(&self, script: String) -> Result<(), Box<ipc_channel::ErrorKind>> {
-        self.sender.send(ToVersoMessage::ExecuteScript(script))
+    pub fn execute_script<S: Into<String>>(
+        &self,
+        script: S,
+    ) -> Result<(), Box<ipc_channel::ErrorKind>> {
+        self.sender
+            .send(ToVersoMessage::ExecuteScript(script.into()))
     }
 
     /// Navigate to url

--- a/versoview_messages/src/lib.rs
+++ b/versoview_messages/src/lib.rs
@@ -161,6 +161,8 @@ pub struct ConfigFromController {
     pub with_panel: bool,
     /// Port number to start a server to listen to remote Firefox devtools connections. 0 for random port.
     pub devtools_port: Option<u16>,
+    /// Start remote WebDriver server on port
+    pub webdriver_port: Option<u16>,
     /// Servo time profile settings
     pub profiler_settings: Option<ProfilerSettings>,
     /// Override the user agent
@@ -195,6 +197,7 @@ impl Default for ConfigFromController {
             url: None,
             with_panel: false,
             devtools_port: None,
+            webdriver_port: None,
             profiler_settings: None,
             user_agent: None,
             user_scripts: Vec::new(),


### PR DESCRIPTION
Some notable changes:

- [`window.screen`](https://developer.mozilla.org/en-US/docs/Web/API/Screen) should now give back the monitor info instead of the window info
- Note: since the move WebDriver API move, most of them are not implemented by Verso (versoview) yet

Except for the Servo bump, here are the changes made to the `verso` crate:

- `VersoviewController::execute_script` now takes `Into<String>` instead of `String`
- Added `VersoBuilder::webdriver_port` to set the WebDriver port through the Rust API