### PR TITLE
Remove the dependency on markupsafe

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -49,10 +49,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      # Needed by stylo, see https://github.com/servo/stylo/pull/215
-      - name: Install markupsafe
-        run: uv pip install markupsafe --system
-
       - name: Check
         run: cargo check
 
@@ -70,10 +66,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-
-      # Needed by stylo, see https://github.com/servo/stylo/pull/215
-      - name: Install markupsafe
-        run: uv pip install markupsafe --system
 
       # Mozangle needs Clang 19+
       # see https://github.com/tauri-apps/verso/actions/runs/15916377747/job/44894669786?pr=20
@@ -99,10 +91,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-
-      # Needed by stylo, see https://github.com/servo/stylo/pull/215
-      - name: Install markupsafe
-        run: uv pip install markupsafe --system
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/release-versoview.yml
+++ b/.github/workflows/release-versoview.yml
@@ -43,10 +43,6 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      # Needed by stylo, see https://github.com/servo/stylo/pull/215
-      - name: Install markupsafe
-        run: uv pip install markupsafe --system
-
       - name: Build
         run: cargo build --profile release-lto
 
@@ -74,10 +70,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-
-      # Needed by stylo, see https://github.com/servo/stylo/pull/215
-      - name: Install markupsafe
-        run: uv pip install markupsafe --system
 
       # Mozangle needs Clang 19+
       # see https://github.com/tauri-apps/verso/actions/runs/15916377747/job/44894669786?pr=20
@@ -118,10 +110,6 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-
-      # Needed by stylo, see https://github.com/servo/stylo/pull/215
-      - name: Install markupsafe
-        run: uv pip install markupsafe --system
 
       - name: Install dependencies
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,7 +271,7 @@ dependencies = [
  "objc2-foundation 0.3.1",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
  "x11rb",
 ]
 
@@ -1273,7 +1273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6474,7 +6474,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6788,7 +6788,7 @@ dependencies = [
 [[package]]
 name = "selectors"
 version = "0.30.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "bitflags 2.9.1",
  "cssparser",
@@ -7014,7 +7014,7 @@ dependencies = [
 [[package]]
 name = "servo_arc"
 version = "0.4.1"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7389,7 +7389,7 @@ dependencies = [
 [[package]]
 name = "stylo"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "app_units",
  "arrayvec",
@@ -7446,7 +7446,7 @@ dependencies = [
 [[package]]
 name = "stylo_atoms"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "string_cache",
  "string_cache_codegen",
@@ -7455,12 +7455,12 @@ dependencies = [
 [[package]]
 name = "stylo_config"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 
 [[package]]
 name = "stylo_derive"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -7472,7 +7472,7 @@ dependencies = [
 [[package]]
 name = "stylo_dom"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "bitflags 2.9.1",
  "stylo_malloc_size_of",
@@ -7481,7 +7481,7 @@ dependencies = [
 [[package]]
 name = "stylo_malloc_size_of"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "app_units",
  "cssparser",
@@ -7498,12 +7498,12 @@ dependencies = [
 [[package]]
 name = "stylo_static_prefs"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 
 [[package]]
 name = "stylo_traits"
 version = "0.5.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "app_units",
  "bitflags 2.9.1",
@@ -7697,7 +7697,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7913,7 +7913,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 [[package]]
 name = "to_shmem"
 version = "0.2.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "cssparser",
  "servo_arc",
@@ -7926,7 +7926,7 @@ dependencies = [
 [[package]]
 name = "to_shmem_derive"
 version = "0.1.0"
-source = "git+https://github.com/servo/stylo?branch=2025-07-01#95cc620f5a5fadf2e4bdacb17e4731c835ab381b"
+source = "git+https://github.com/servo/stylo?branch=2025-07-01#22df130e1485834f336b8543e5f12b9e717ca620"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -9161,7 +9161,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ Verso is still under development. We don't accept feature requests at the moment
 
 ```sh
 scoop install git python uv llvm cmake curl
-# Needed by stylo, see https://github.com/servo/stylo/pull/215
-pip install markupsafe
 ```
 
 > You can also use chocolatey to install if you prefer it.
@@ -40,8 +38,6 @@ cargo run
 
 ```sh
 brew install cmake pkg-config harfbuzz uv
-# Needed by stylo, see https://github.com/servo/stylo/pull/215
-pip install markupsafe
 ```
 
 - Build & run:


### PR DESCRIPTION
The dependency was introduced in #21 because `stylo` vendered in `mako` but not its dependencies, and it is now resolved with https://github.com/servo/stylo/pull/215 being merged, we can remove it from our CI and readme now