### PR TITLE
Fix crash on sending data URL to controller

### DIFF
--- a/src/webview/webview.rs
+++ b/src/webview/webview.rs
@@ -174,12 +174,25 @@ impl Window {
                         for (key, value) in request.headers.iter() {
                             builder = builder.header(key, value);
                         }
+                        // TODO: Actually send the body
+                        let http_request = match builder.body(Vec::new()) {
+                            Ok(request) => request,
+                            Err(error) => {
+                                if request.url.scheme() == "data" {
+                                    log::debug!(
+                                        "We currently skip data URLs as they can't be parsed into a `http::Uri`: {error}"
+                                    );
+                                } else {
+                                    log::error!("Failed to construct a request: {error}");
+                                }
+                                return;
+                            }
+                        };
                         match to_controller_sender.send(
                             ToControllerMessage::OnWebResourceRequested(
                                 versoview_messages::WebResourceRequest {
                                     id,
-                                    // TODO: Actually send the body
-                                    request: builder.body(Vec::new()).unwrap(),
+                                    request: http_request,
                                 },
                             ),
                         ) {
@@ -202,26 +215,21 @@ impl Window {
                     .map(|c| {
                         c.get_text().unwrap_or_else(|e| {
                             log::warn!(
-                                "Verso WebView {webview_id:?} failed to get clipboard text: {}",
-                                e
+                                "Verso WebView {webview_id:?} failed to get clipboard text: {e}",
                             );
                             String::new()
                         })
                     })
                     .unwrap_or_default();
                 if let Err(e) = sender.send(Ok(text)) {
-                    log::warn!(
-                        "Verso WebView {webview_id:?} failed to send clipboard text: {}",
-                        e
-                    );
+                    log::warn!("Verso WebView {webview_id:?} failed to send clipboard text: {e}",);
                 }
             }
             EmbedderMsg::SetClipboardText(_webview_id, text) => {
                 if let Some(c) = clipboard {
                     if let Err(e) = c.set_text(text) {
                         log::warn!(
-                            "Verso WebView {webview_id:?} failed to set clipboard text: {}",
-                            e
+                            "Verso WebView {webview_id:?} failed to set clipboard text: {e}",
                         );
                     }
                 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -4,9 +4,9 @@ use base::{generic_channel::GenericSender, id::WebViewId};
 use constellation_traits::EmbedderToConstellationMessage;
 use crossbeam_channel::Sender;
 use embedder_traits::{
-    AlertResponse, AllowOrDeny, ConfirmResponse, Cursor, EmbedderMsg,  ImeEvent,
-    InputEvent, MouseButton, MouseButtonAction, MouseButtonEvent, MouseLeftViewportEvent,
-    MouseMoveEvent, Notification, PromptResponse, ScreenMetrics, TouchEventType, ViewportDetails,
+    AlertResponse, AllowOrDeny, ConfirmResponse, Cursor, EmbedderMsg, ImeEvent, InputEvent,
+    MouseButton, MouseButtonAction, MouseButtonEvent, MouseLeftViewportEvent, MouseMoveEvent,
+    Notification, PromptResponse, ScreenMetrics, TouchEventType, ViewportDetails,
     WebResourceResponseMsg, WheelMode,
 };
 use euclid::{Point2D, Scale, Size2D};
@@ -378,9 +378,9 @@ impl Window {
                 );
 
                 self.focused_webview_id = Some(tab_id);
-                let _ = compositor.constellation_sender.send(
-                    EmbedderToConstellationMessage::FocusWebView(tab_id),
-                );
+                let _ = compositor
+                    .constellation_sender
+                    .send(EmbedderToConstellationMessage::FocusWebView(tab_id));
 
                 // Set navigation button enabled state
                 let history = self.tab_manager.history(tab_id).unwrap();

--- a/verso/src/lib.rs
+++ b/verso/src/lib.rs
@@ -264,7 +264,10 @@ impl VersoviewController {
     /// which you can return `Some(response)` to intercept the request with a custom respond,
     /// or returning a `None` to use the default handlings
     ///
-    /// Note: you must respond to the request or else the request will never complete
+    /// Notes:
+    ///
+    /// - You must respond to the request or else the request will never complete
+    /// - Data URL requests are not sent to the controller
     ///
     /// ## Examples
     ///

--- a/verso/src/lib.rs
+++ b/verso/src/lib.rs
@@ -258,8 +258,33 @@ impl VersoviewController {
         Ok(())
     }
 
-    /// Listen on web resource requests,
-    /// return a boolean in the callback to decide whether or not allowing this navigation
+    /// Listen on web resource requests and maybe intercept them,
+    /// the closure takes 2 parameters, a request and a response function,
+    /// the response function takes an optional response,
+    /// which you can return `Some(response)` to intercept the request with a custom respond,
+    /// or returning a `None` to use the default handlings
+    ///
+    /// Note: you must respond to the request or else the request will never complete
+    ///
+    /// ## Examples
+    ///
+    /// ```
+    /// let controller = verso::VersoBuilder::new()
+    ///     .build("versoview", url::Url::parse("https://example.com/").unwrap());
+    /// controller
+    ///     .on_web_resource_requested(|request, response| {
+    ///         if request.uri() == "https://example.com/" {
+    ///             response(Some(
+    ///                 http::Response::builder()
+    ///                     .body("Intercepted!".as_bytes().to_vec())
+    ///                     .unwrap(),
+    ///             ));
+    ///         } else {
+    ///             response(None);
+    ///         }
+    ///     })
+    ///     .unwrap();
+    /// ```
     pub fn on_web_resource_requested(
         &self,
         callback: impl Fn(http::Request<Vec<u8>>, ResponseFunction) + Send + 'static,


### PR DESCRIPTION
So a data URL can't be converted to a `http:Uri`, in this PR, we disable sending data URLs to controllers for now

Also corrected and expanded the documentations for `on_web_resource_requested`